### PR TITLE
Add support for attribute changed callback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,8 @@ const elmWebComponents = {
       mapFlags = flags => flags,
       onSetupError,
       useShadowDom = false,
+      onAttributeChanged = () => {},
+      setObservedAttributes = () => {},
     } = {}
   ) {
     if (!this.__elmVersion) {
@@ -83,14 +85,14 @@ const elmWebComponents = {
             parentDiv.innerHTML = ''
             parentDiv.appendChild(elmDiv)
 
-            const elmElement = ElmComponent.init({
+            this.elmElement = ElmComponent.init({
               flags,
               node: elmDiv,
             })
-            setupPorts(elmElement.ports)
+            setupPorts(this.elmElement.ports)
           } else if (elmVersion === '0.18') {
-            const elmElement = ElmComponent.embed(parentDiv, flags)
-            setupPorts(elmElement.ports)
+            this.elmElement = ElmComponent.embed(parentDiv, flags)
+            setupPorts(this.elmElement.ports)
           }
         } catch (error) {
           if (onSetupError) {
@@ -103,6 +105,15 @@ const elmWebComponents = {
             )
           }
         }
+      }
+
+      static get observedAttributes() {
+        return setObservedAttributes();
+      }
+
+      attributeChangedCallback(name, oldValue, newValue) {
+        if (!this.elmElement) return;
+        onAttributeChanged(name, oldValue, newValue, this.elmElement.ports);
       }
 
       disconnectedCallback() {


### PR DESCRIPTION
This would allow an elm web component to update itself when a property is changed. A port would need to be added on the elm side to handle the change.

This is useful when an elm web component needs to be updated dynamically. Especially within another elm app.

Would fix https://github.com/thread/elm-web-components/issues/19

Example:
```
  onAttributeChanged: (name, oldValue, newValue, ports) => {
    switch (name) {
      case 'page_number':
      ports.pageNumberAttributeChanged.send(parseInt(newValue, 10));
      break;
    }
  },
  setObservedAttributes: () => { return ['page_number'] },
```